### PR TITLE
reverse 18i8gen3 analogue out channel mapping

### DIFF
--- a/debug-drv/mixer_scarlett_gen2.c
+++ b/debug-drv/mixer_scarlett_gen2.c
@@ -1158,7 +1158,7 @@ static const struct scarlett2_sw_port_mapping s18i8_gen3_sw_port_mapping[] = {
 	{ -1, -1, -1, -1}
 };
 
-static const u8 s18i8_analogue_out_remapping[8] = { 0, 1, 6, 7, 2, 3, 4, 5 };
+static const u8 s18i8_analogue_out_remapping[8] = { 0, 1, 4, 5, 6, 7, 2, 3 };
 
 static const struct scarlett2_device_info s18i8_gen3_info = {
 	.usb_id = USB_ID(0x1235, 0x8214),


### PR DESCRIPTION
The current code does the mapping for the analogue output channels in the wrong direction for the 18i8 gen3 device.
When using the inverse permutation instead, the names mapped to the port number reflect the output jack numbers on the back of the device.

This patch replaces the current output channel permutation with its inverse, which corrects the mapping to be like the following:
Main monitor L -> Analogue Out 01 (output jack 1)
Main monitor R -> Analogue Out 02 (output jack 2)
Alt monitor L -> Analogue Out 03 (output jack 3)
Alt monitor L -> Analogue Out 04 (output jack 4)

Headphones 1 L/R -> Analogue Out 05/06 (headphones jack 1)
Headphones 2 L/R -> Analogue Out 07/08 (headphones jack 2)
